### PR TITLE
Remove redundant lines in mass_spring.py clear_states()

### DIFF
--- a/examples/mass_spring.py
+++ b/examples/mass_spring.py
@@ -275,10 +275,7 @@ def forward(output=None, visualize=True):
 def clear_states():
     for t in range(0, max_steps):
         for i in range(0, n_objects):
-            x.grad[t, i] = ti.Vector([0.0, 0.0])
-            v.grad[t, i] = ti.Vector([0.0, 0.0])
             v_inc[t, i] = ti.Vector([0.0, 0.0])
-            v_inc.grad[t, i] = ti.Vector([0.0, 0.0])
 
 
 def clear():
@@ -322,7 +319,7 @@ def optimize(toi, visualize):
     # forward('initial{}'.format(robot_id), visualize=visualize)
     for iter in range(100):
         clear()
-
+        # with ti.Tape(loss) automatically clears all gradients
         with ti.Tape(loss):
             forward(visualize=visualize)
 


### PR DESCRIPTION
As I was playing around with mass_spring.py, I got confused by clear_states(). I was curious why only some of the variable gradients were being cleared. I dug into the TaiChi code and found that `with Tape(loss)` seems to clear all the variable gradients automatically, so there is no need to clear them in clear_states(). The only thing clear_states() needs to do is reset v_inc. 

This shouldn't change how mass_spring.py runs at all (Although I cannot guarantee this because it seems that mass_spring.py is non deterministic and I get a slightly different result each time I run it). This edit should only help reduce confusion for new users.

However, if I have misunderstood clear_states(), let me know. I'm still pretty new to TaiChi.