### PR TITLE
Migrate to the new taichi GUI system

### DIFF
--- a/examples/billiards.py
+++ b/examples/billiards.py
@@ -97,7 +97,7 @@ def initialize():
     v[0, 0] = init_v
 
 
-gui = ti.core.GUI("Billiards", ti.veci(1024, 1024))
+gui = ti.GUI("Billiards", (1024, 1024), background_color=0x3C733F)
 
 
 def forward(visualize=False, output=None):
@@ -118,16 +118,13 @@ def forward(visualize=False, output=None):
 
     pixel_radius = int(radius * 1024) + 1
 
-    canvas = gui.get_canvas()
     for t in range(1, steps):
         collide(t - 1)
         advance(t)
 
         if (t + 1) % interval == 0 and visualize:
-            canvas.clear(0x3C733F)
-
-            canvas.circle(ti.vec(goal[0], goal[1])).radius(
-                pixel_radius // 2).color(0x00000).finish()
+            gui.clear()
+            gui.circle((goal[0], goal[1]), 0x00000, pixel_radius // 2)
 
             for i in range(n_balls):
                 if i == 0:
@@ -137,13 +134,12 @@ def forward(visualize=False, output=None):
                 else:
                     color = 0xF20530
 
-                canvas.circle(ti.vec(
-                    x[t, i][0],
-                    x[t, i][1])).radius(pixel_radius).color(color).finish()
+                gui.circle((x[t, i][0], x[t, i][1]), color, pixel_radius)
 
-            gui.update()
             if output:
-                gui.screenshot('billiards/{}/{:04d}.png'.format(output, t))
+                gui.show('billiards/{}/{:04d}.png'.format(output, t))
+            else:
+                gui.show()
 
     compute_loss(steps - 1)
 

--- a/examples/electric.py
+++ b/examples/electric.py
@@ -112,7 +112,7 @@ def compute_loss(t: ti.i32):
     ti.atomic_add(loss[None], dt * (x[t] - goal[t]).norm_sqr())
 
 
-gui = ti.core.GUI("Electric", ti.veci(1024, 1024))
+gui = ti.GUI("Electric", (1024, 1024), background_color=0x3C733F)
 
 
 def forward(visualize=False, output=None):
@@ -121,7 +121,6 @@ def forward(visualize=False, output=None):
         interval = output_vis_interval
         os.makedirs('electric/{}/'.format(output), exist_ok=True)
 
-    canvas = gui.get_canvas()
     for t in range(1, steps):
         nn1(t)
         nn2(t)
@@ -129,22 +128,19 @@ def forward(visualize=False, output=None):
         compute_loss(t)
 
         if (t + 1) % interval == 0 and visualize:
-            canvas.clear(0x3C733F)
+            gui.clear()
 
             for i in range(n_gravitation):
                 r = (gravitation[t, i] + 1) * 30
-                canvas.circle(ti.vec(*gravitation_position[i])).radius(
-                    r).color(0xccaa44).finish()
+                gui.circle(gravitation_position[i], 0xccaa44, r)
 
-            canvas.circle(ti.vec(x[t][0],
-                                 x[t][1])).radius(30).color(0xF20530).finish()
+            gui.circle((x[t][0], x[t][1]), 0xF20530, 30)
+            gui.circle((goal[t][0], goal[t][1]), 0x3344cc, 10)
 
-            canvas.circle(ti.vec(
-                goal[t][0], goal[t][1])).radius(10).color(0x3344cc).finish()
-
-            gui.update()
             if output:
-                gui.screenshot('electric/{}/{:04d}.png'.format(output, t))
+                gui.show('electric/{}/{:04d}.png'.format(output, t))
+            else:
+                gui.show()
 
 
 def rand():

--- a/examples/liquid.py
+++ b/examples/liquid.py
@@ -4,7 +4,6 @@ import os
 import math
 import numpy as np
 import random
-import cv2
 import matplotlib.pyplot as plt
 import time
 
@@ -373,10 +372,6 @@ class Scene:
     def set_n_actuators(self, n_act):
         global n_actuators
         n_actuators = n_act
-
-
-gui = ti.core.GUI("Differentiable MPM", ti.veci(1024, 1024))
-canvas = gui.get_canvas()
 
 
 @ti.kernel

--- a/examples/mass_spring.py
+++ b/examples/mass_spring.py
@@ -198,8 +198,7 @@ def compute_loss(t: ti.i32):
     loss[None] = -x[t, head_id][0]
 
 
-gui = ti.core.GUI("Mass Spring Robot", ti.veci(1024, 1024))
-canvas = gui.get_canvas()
+gui = ti.GUI("Mass Spring Robot", (1024, 1024), background_color=0xFFFFFF)
 
 
 def forward(output=None, visualize=True):
@@ -227,18 +226,16 @@ def forward(output=None, visualize=True):
             advance_no_toi(t)
 
         if (t + 1) % interval == 0 and visualize:
-            canvas.clear(0xFFFFFF)
-            canvas.path(ti.vec(0, ground_height),
-                        ti.vec(1, ground_height)).color(0x0).radius(3).finish()
+            gui.clear()
+            gui.line((0, ground_height), (1, ground_height), 0x0, 3)
 
             def circle(x, y, color):
-                canvas.circle(ti.vec(x, y)).color(
-                    ti.rgb_to_hex(color)).radius(7).finish()
+                gui.circle((x, y), ti.rgb_to_hex(color), 7)
 
             for i in range(n_springs):
 
                 def get_pt(x):
-                    return ti.vec(x[0], x[1])
+                    return (x[0], x[1])
 
                 a = act[t - 1, i] * 0.5
                 r = 2
@@ -248,10 +245,9 @@ def forward(output=None, visualize=True):
                 else:
                     r = 4
                     c = ti.rgb_to_hex((0.5 + a, 0.5 - abs(a), 0.5 - a))
-                canvas.path(
+                gui.line(
                     get_pt(x[t, spring_anchor_a[i]]),
-                    get_pt(x[t,
-                             spring_anchor_b[i]])).color(c).radius(r).finish()
+                    get_pt(x[t, spring_anchor_b[i]]), c, r)
 
             for i in range(n_objects):
                 color = (0.4, 0.6, 0.6)
@@ -260,9 +256,10 @@ def forward(output=None, visualize=True):
                 circle(x[t, i][0], x[t, i][1], color)
             # circle(goal[None][0], goal[None][1], (0.6, 0.2, 0.2))
 
-            gui.update()
             if output:
-                gui.screenshot('mass_spring/{}/{:04d}.png'.format(output, t))
+                gui.show('mass_spring/{}/{:04d}.png'.format(output, t))
+            else:
+                gui.show()
 
     loss[None] = 0
     compute_loss(steps - 1)

--- a/examples/mass_spring_velocity.py
+++ b/examples/mass_spring_velocity.py
@@ -198,10 +198,7 @@ def compute_loss(t: ti.i32):
     ti.atomic_add(loss[None], dt * (target_v[t][0] - v[t, head_id][0]))**2
 
 
-gui = ti.core.GUI("Mass Spring Robot", ti.veci(1024, 1024))
-canvas = gui.get_canvas()
-
-from taichi import rgb_to_hex
+gui = ti.GUI("Mass Spring Robot", (1024, 1024), background_color=0xFFFFFF)
 
 
 def forward(output=None, visualize=True):
@@ -237,19 +234,16 @@ def forward(output=None, visualize=True):
         compute_loss(t)
 
         if (t + 1) % interval == 0 and visualize:
-            canvas.clear(0xFFFFFF)
-            canvas.path(ti.vec(0, ground_height),
-                        ti.vec(1,
-                               ground_height)).color(0x0).radius(3).finish()
+            gui.clear()
+            gui.line((0, ground_height), (1, ground_height), 0x0, 3)
 
             def circle(x, y, color):
-                canvas.circle(ti.vec(x, y)).color(
-                    rgb_to_hex(color)).radius(7).finish()
+                gui.circle((x, y), ti.rgb_to_hex(color), 7)
 
             for i in range(n_springs):
 
                 def get_pt(x):
-                    return ti.vec(x[0], x[1])
+                    return (x[0], x[1])
 
                 a = act[t - 1, i] * 0.5
                 r = 2
@@ -258,11 +252,10 @@ def forward(output=None, visualize=True):
                     c = 0x222222
                 else:
                     r = 4
-                    c = rgb_to_hex((0.5 + a, 0.5 - abs(a), 0.5 - a))
-                canvas.path(
+                    c = ti.rgb_to_hex((0.5 + a, 0.5 - abs(a), 0.5 - a))
+                gui.line(
                     get_pt(x[t, spring_anchor_a[i]]),
-                    get_pt(x[t,
-                             spring_anchor_b[i]])).color(c).radius(r).finish()
+                    get_pt(x[t, spring_anchor_b[i]]), c, r)
 
             for i in range(n_objects):
                 color = (0.4, 0.6, 0.6)
@@ -278,9 +271,10 @@ def forward(output=None, visualize=True):
                 circle(0.5, 0.5, (0, 0, 1))
                 circle(0.4, 0.5, (0, 0, 1))
 
-            gui.update()
             if output:
-                gui.screenshot('mass_spring/{}/{:04d}.png'.format(output, t))
+                gui.show('mass_spring/{}/{:04d}.png'.format(output, t))
+            else:
+                gui.show()
 
 
 @ti.kernel

--- a/examples/rigid_body_discountinuity.py
+++ b/examples/rigid_body_discountinuity.py
@@ -158,8 +158,7 @@ def compute_loss(t: ti.i32):
     loss[None] = x[t, head_id][0]
 
 
-gui = ti.core.GUI("Rigid Body", ti.veci(1024, 1024))
-canvas = gui.get_canvas()
+gui = ti.GUI("Rigid Body", (1024, 1024), background_color=0xFFFFFF)
 
 
 def forward(output=None, visualize=True):
@@ -178,7 +177,7 @@ def forward(output=None, visualize=True):
         advance(t)
 
         if (t + 1) % interval == 0 and visualize:
-            canvas.clear(0xFFFFFF)
+            gui.clear()
             for i in range(n_objects):
                 points = []
                 for k in range(4):
@@ -194,20 +193,16 @@ def forward(output=None, visualize=True):
                     points.append((pos[0], pos[1]))
 
                 for k in range(4):
-                    canvas.path(
-                        ti.vec(*points[k]),
-                        ti.vec(*points[(k + 1) %
-                                       4])).radius(2).color(0x0).finish()
+                    gui.line(points[k], points[(k + 1) % 4], 0x0, 2)
 
             offset = 0.003
-            canvas.path(ti.vec(0.05, ground_height - offset),
-                        ti.vec(0.95, ground_height -
-                               offset)).radius(2).color(0xAAAAAA).finish()
+            gui.line((0.05, ground_height - offset),
+                     (0.95, ground_height - offset), 0xAAAAAA, 2)
 
             if output:
                 gui.screenshot('rigid_body/{}/{:04d}.png'.format(output, t))
-
-            gui.update()
+            else:
+                gui.show()
 
     loss[None] = 0
     compute_loss(steps - 1)
@@ -238,7 +233,7 @@ def main():
             clear_states()
 
             with ti.Tape(loss):
-                forward(visualize=False)
+                forward(visualize=True)
 
             print('Iter=', i, 'Loss=', loss[None])
             print(omega.grad[0, 0])

--- a/examples/rigid_body_toi.py
+++ b/examples/rigid_body_toi.py
@@ -76,9 +76,7 @@ def compute_loss(t: ti.i32):
     loss[None] = x[t, 0][1]
 
 
-gui = ti.core.GUI("Rigid Body", ti.veci(1024, 1024))
-canvas = gui.get_canvas()
-
+gui = ti.GUI("Rigid Body", (1024, 1024), background_color=0xFFFFFF)
 
 def forward(output=None, visualize=True):
     interval = vis_interval
@@ -95,18 +93,16 @@ def forward(output=None, visualize=True):
             advance_no_toi(t)
 
         if (t + 1) % interval == 0 and visualize:
-            canvas.clear(0xFFFFFF)
-            canvas.circle(ti.vec(x[t, 0][0],
-                                 x[t, 0][1])).radius(10).color(0x0).finish()
+            gui.clear()
+            gui.circle((x[t, 0][0], x[t, 0][1]), 0x0, 10)
             offset = 0.003
-            canvas.path(ti.vec(0.05, ground_height - offset),
-                        ti.vec(0.95, ground_height -
-                               offset)).radius(2).color(0xAAAAAA).finish()
+            gui.line((0.05, ground_height - offset),
+                     (0.95, ground_height - offset), 0xAAAAAA, 2)
 
             if output:
-                gui.screenshot('rigid_body/{}/{:04d}.png'.format(output, t))
-
-            gui.update()
+                gui.show('rigid_body/{}/{:04d}.png'.format(output, t))
+            else:
+                gui.show()
 
     loss[None] = 0
     compute_loss(steps - 1)

--- a/examples/rigid_body_toi_visualize.py
+++ b/examples/rigid_body_toi_visualize.py
@@ -70,8 +70,7 @@ def advance_no_toi(t: ti.i32):
         x[t, i] = x[t - 1, i] + dt * new_v
 
 
-gui = ti.core.GUI("Rigid Body", ti.veci(1024, 1024))
-canvas = gui.get_canvas()
+gui = ti.GUI("Rigid Body", (1024, 1024), background_color=0xFFFFFF)
 
 
 def forward(output=None, visualize=True, dy=0, i=0):
@@ -83,7 +82,7 @@ def forward(output=None, visualize=True, dy=0, i=0):
     if output:
         os.makedirs('rigid_body_toi/{}/'.format(output), exist_ok=True)
 
-    canvas.clear(0xFFFFFF)
+    gui.clear()
     for t in range(1, total_steps):
         if use_toi:
             advance_toi(t)
@@ -93,16 +92,15 @@ def forward(output=None, visualize=True, dy=0, i=0):
         if (t + 1) % interval == 0 and visualize:
             color = 0x010101 * min(
                 255, max(0, int((1 - t * dt / total_t) * 0.7 * 255)))
-            canvas.circle(ti.vec(x[t, 0][0],
-                                 x[t, 0][1])).radius(80).color(color).finish()
+            gui.circle((x[t, 0][0], x[t, 0][1]), color, 80)
             offset = 0.077
-            canvas.path(ti.vec(0.05, ground_height - offset),
-                        ti.vec(0.95, ground_height -
-                               offset)).radius(2).color(0x000000).finish()
+            gui.line((0.05, ground_height - offset),
+                     (0.95, ground_height - offset), 0x000000, 2)
 
     if output:
-        gui.screenshot('rigid_body_toi/{}/{:04d}.png'.format(output, i))
-    gui.update()
+        gui.show('rigid_body_toi/{}/{:04d}.png'.format(output, i))
+    else:
+        gui.show()
 
 
 def main():


### PR DESCRIPTION
As per https://github.com/taichi-dev/taichi/issues/1651#event-3627402037 all of the example code is using the deprecated taichi GUI system (`ti.core.GUI`). This PR migrates all of the examples to the new GUI framework (https://taichi.readthedocs.io/en/stable/gui.html).

Note that although all of the code runs without error and the DeprecationWarnings are gone, I found there to be strange bugs around `gui.line(...)`. In particular just calling `gui.line` completely blacks out the screen in some examples (`rigid_body_toi.py`) and seems to have no effect in others (`rigid_body_toi_visualize.py`). I haven't bothered to poke around into the internals of the GUI system to chase down those bugs. This PR is a direct refactor that retains semantics and assumes a bug free implementation of the new GUI API.