### PR TITLE
Fix missed ti.Vector -> ti.Vector.field causing TypeError

### DIFF
--- a/examples/diffmpm_checkpointing.py
+++ b/examples/diffmpm_checkpointing.py
@@ -24,8 +24,8 @@ gravity = 9.8
 target = [0.3, 0.6]
 
 scalar = lambda: ti.field(dtype=real)
-vec = lambda: ti.Vector(dim, dtype=real)
-mat = lambda: ti.Matrix(dim, dim, dtype=real)
+vec = lambda: ti.Vector.field(dim, dtype=real)
+mat = lambda: ti.Matrix.field(dim, dim, dtype=real)
 
 x = ti.Vector.field(dim,
                     dtype=real,

--- a/examples/diffmpm_simple.py
+++ b/examples/diffmpm_simple.py
@@ -22,8 +22,8 @@ gravity = 9.8
 target = [0.3, 0.6]
 
 scalar = lambda: ti.field(dtype=real)
-vec = lambda: ti.Vector(dim, dtype=real)
-mat = lambda: ti.Matrix(dim, dim, dtype=real)
+vec = lambda: ti.Vector.field(dim, dtype=real)
+mat = lambda: ti.Matrix.field(dim, dim, dtype=real)
 
 x = ti.Vector.field(dim,
                     dtype=real,

--- a/examples/mass_spring_simple.py
+++ b/examples/mass_spring_simple.py
@@ -22,7 +22,7 @@ spring_stiffness = 10
 damping = 20
 
 scalar = lambda: ti.field(dtype=real)
-vec = lambda: ti.Vector(2, dtype=real)
+vec = lambda: ti.Vector.field(2, dtype=real)
 
 loss = scalar()
 x = vec()


### PR DESCRIPTION
```
(master) [bate@archit examples]$ p mass_spring_simple.py 
[Taichi] mode=release
[Taichi] preparing sandbox at /tmp/taichi-j1nqa728
[Taichi] version 0.6.27, llvm 10.0.0, commit a34a6128, linux, python 3.8.3
[Taichi] Starting on arch=x64
Traceback (most recent call last):
  File "mass_spring_simple.py", line 28, in <module>
    x = vec()
  File "mass_spring_simple.py", line 25, in <lambda>
    vec = lambda: ti.Vector(2, dtype=real)
  File "/home/bate/.local/lib/python3.8/site-packages/taichi/lang/matrix.py", line 964, in Vector
    return Matrix(n, 1, dt=dt, shape=shape, offset=offset, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'dtype'
```
Please always run the examples before commiting the change :)
Actually you could ask @Rullec for this task, who is very familiar with such refactor workflow in our Taichi main repo.