### PR TITLE
Enable objective_with_grad in smoke_jax.py

### DIFF
--- a/examples/smoke_jax.py
+++ b/examples/smoke_jax.py
@@ -175,7 +175,7 @@ if __name__ == '__main__':
         return distance_from_target_image(final_smoke)
 
     # Specify gradient of objective function using JAX.
-    #objective_with_grad = value_and_grad(objective)
+    objective_with_grad = value_and_grad(objective)
 
     import time
     for i in range(10):


### PR DESCRIPTION
`result = minimize(objective_with_grad, ...` will crash if this line is commented out.